### PR TITLE
Update com.behringer.XAirEdit.yml

### DIFF
--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -24,7 +24,7 @@ modules:
   - type: script
     dest-filename: apply_extra
     commands:
-    - tar xvf X-AIR-Edit_LINUX_X64_V1.5.tar.gz
+    - tar xvf X-AIR-Edit_LINUX_1.5.tar.gz
   - type: file
     path: com.behringer.XAirEdit.desktop
   - type: file
@@ -32,9 +32,9 @@ modules:
   - type: file
     path: com.behringer.XAirEdit.png
   - type: extra-data
-    filename: X-AIR-Edit_LINUX_X64_V1.5.tar.gz
+    filename: X-AIR-Edit_LINUX_1.5.tar.gz
     only-arches:
     - x86_64
-    url: https://mediadl.musictribe.com/download/software/behringer/XAIR/X-AIR-Edit_LINUX_X64_V1.5.tar.gz
+    url: https://mediadl.musictribe.com/download/software/behringer/XAIR/X-AIR-Edit_LINUX_1.5.tar.gz
     sha256: 3733b829ed07319f786add8654619e70bc9e7bbcad41b6d11bf6cd93e5ffe3c5
     size: 6878502

--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -1,6 +1,6 @@
 app-id: com.behringer.XAirEdit
 runtime: org.freedesktop.Platform
-runtime-version: "20.08.15"
+runtime-version: "20.08"
 sdk: org.freedesktop.Sdk
 command: X-AIR-Edit
 tags:

--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -1,6 +1,6 @@
 app-id: com.behringer.XAirEdit
 runtime: org.freedesktop.Platform
-runtime-version: "19.08"
+runtime-version: "20.08.15"
 sdk: org.freedesktop.Sdk
 command: X-AIR-Edit
 tags:

--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -1,6 +1,6 @@
 app-id: com.behringer.XAirEdit
 runtime: org.freedesktop.Platform
-runtime-version: "20.08"
+runtime-version: "21.08"
 sdk: org.freedesktop.Sdk
 command: X-AIR-Edit
 tags:


### PR DESCRIPTION
The URL has changed. Same file, they just removed the "x64" and "V" before "1.5" from the filename. I'm guessing it's because they removed the 32bit version of X-Air Edit and therefor didn't need to qualify arch anymore.