### PR TITLE
Update to version 1.8, and add x-checker-data

### DIFF
--- a/com.behringer.XAirEdit.metainfo.xml
+++ b/com.behringer.XAirEdit.metainfo.xml
@@ -21,7 +21,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release date="2021-04-28"version="1.7">
+    <release date="2021-04-28" version="1.7">
       <description>
         <ul>
           <li>Preventing sleep on MAC (no App Nap)</li>

--- a/com.behringer.XAirEdit.metainfo.xml
+++ b/com.behringer.XAirEdit.metainfo.xml
@@ -21,6 +21,21 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.8" date="2023-06-21">
+      <description>
+        <ul>
+          <li>Added support for V2 mixers with alternative MCU, FPGA, USB, WIFI module: XR18V2, X18V2</li>
+          <li>Added support for mixers with alternative WIFI module: XR12W, XR16W</li>
+          <li>Improved load/save 'working directory' directory handling on all OS</li>
+          <li>Improved RTA Source handling, fixed Solo Priority</li>
+          <li>Improved EQ graph display with eq numbers and frequency lines</li>
+          <li>Fixed multiple connect popup issue</li>
+          <li>Fixed panning feedback on linked channels during sync from pc to mixer</li>
+          <li>Fixed Stereo De-esser m/s process sync</li>
+          <li>Fixes for touch interface glitches</li>
+        </ul>
+      </description>
+    </release>
     <release date="2021-04-28" version="1.7">
       <description>
         <ul>
@@ -35,5 +50,5 @@
     </release>
     <release date="2017-01-30" version="1.5"/>
   </releases>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
 </component>

--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -30,7 +30,7 @@ modules:
   - type: script
     dest-filename: apply_extra
     commands:
-    - tar -zxv --no-same-owner -f X-AIR-Edit_LINUX_1.8.tar.gz
+    - tar -zxv --no-same-owner -f X-AIR-Edit_LINUX.tar.gz
     - patchelf --replace-needed libcurl-gnutls.so.4 libcurl.so.4 X-AIR-Edit
   - type: file
     path: com.behringer.XAirEdit.desktop
@@ -39,9 +39,15 @@ modules:
   - type: file
     path: com.behringer.XAirEdit.png
   - type: extra-data
-    filename: X-AIR-Edit_LINUX_1.8.tar.gz
+    filename: X-AIR-Edit_LINUX.tar.gz
     only-arches:
     - x86_64
     url: https://mediadl.musictribe.com/download/software/behringer/XAIR/X-AIR-Edit_LINUX_1.8.tar.gz
     sha256: 1b04d96d30999ab880ca0766b820dcc5e5ecb05a56b23e0beb2368fce150187d
     size: 8462220
+    x-checker-data:
+      type: json
+      url: https://www.behringer.com/.rest/musictribe/v1/products/media-library?brandName=behringer&modelCode=P0BI8
+      version-query: .[] | select(.title=="Software") | .list[] | select(.title | contains("X-AIR Edit (Linux)")).title | sub("^X-AIR Edit \\(Linux\\) Version ";"")
+      url-query: .[] | select(.title == "Software") | .list[] | select(.title == "X-AIR Edit (Linux) Version " + $version).url
+      is-main-source: true

--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -30,7 +30,7 @@ modules:
   - type: script
     dest-filename: apply_extra
     commands:
-    - tar -zxv --no-same-owner -f X-AIR-Edit_LINUX_1.7.tar.gz
+    - tar -zxv --no-same-owner -f X-AIR-Edit_LINUX_1.8.tar.gz
     - patchelf --replace-needed libcurl-gnutls.so.4 libcurl.so.4 X-AIR-Edit
   - type: file
     path: com.behringer.XAirEdit.desktop
@@ -39,9 +39,9 @@ modules:
   - type: file
     path: com.behringer.XAirEdit.png
   - type: extra-data
-    filename: X-AIR-Edit_LINUX_1.7.tar.gz
+    filename: X-AIR-Edit_LINUX_1.8.tar.gz
     only-arches:
     - x86_64
-    url: https://mediadl.musictribe.com/download/software/behringer/XAIR/X-AIR-Edit_LINUX_1.7.tar.gz
-    sha256: 72e638ed9b534be760174db1e59fd7e1852d3759b65cd6045db877b3b3e616b3
-    size: 7408538
+    url: https://mediadl.musictribe.com/download/software/behringer/XAIR/X-AIR-Edit_LINUX_1.8.tar.gz
+    sha256: 1b04d96d30999ab880ca0766b820dcc5e5ecb05a56b23e0beb2368fce150187d
+    size: 8462220


### PR DESCRIPTION
This will automatically create PRs for future versions of X Air Edit, using [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) via @flathubbot.

Closes #12 