### PR TITLE
Add --filesystem=home permissions

### DIFF
--- a/com.behringer.XAirEdit.yml
+++ b/com.behringer.XAirEdit.yml
@@ -10,6 +10,7 @@ finish-args:
 - --socket=x11
 - --share=network
 - --device=dri
+- --filesystem=home
 modules:
 - name: patchelf
   sources:


### PR DESCRIPTION
This is required, otherwise:

- Config is not stored, breaking the "auto connect" functionality. This fixes #10.
- User will not be able to load/store scene or channel presets. This fixes #11.

(This should be applied before #13 and then #13 would need to be rebased onto master.)